### PR TITLE
Fix UI for role selection in Builder

### DIFF
--- a/jam/js/admin.js
+++ b/jam/js/admin.js
@@ -859,7 +859,7 @@ function Events2() { // sys_roles
 
 	function on_view_form_created(item) {
 		let w = '70px',
-			table_height = task.center_panel.height() - item.task.view_panel.height();
+			table_height = Math.max(task.center_panel.height() - item.task.view_panel.height(), 400);
 		item.edit_options.fields = ['f_name'];
 		item.edit_options.title = item.task.language.roles + task.help_badge('https://jampy-docs-v7.readthedocs.io/en/latest/admin/roles.html');
 		if (item.view_form.hasClass('modal')) {


### PR DESCRIPTION
Fix UI in Builder for user dialog set/change Role.
The list of roles is compressed vertically, only one row with the role is visible.

<img width="1231" height="897" alt="bug-builder-change-role" src="https://github.com/user-attachments/assets/370086c7-ee74-446c-8b51-fd9f328c3ac4" />
